### PR TITLE
Stop tip footer only for prefix interactions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ module.exports = async function (input, options = {}) {
             color: options.embedColor,
             fields: [],
             author: { name: usertag, icon_url: avatar },
-            footer: { text: translations.stopTip }
+            footer: { text: !input.user ? translations.stopTip : "" }
         }
 
         if (!options.useButtons) { 
@@ -268,7 +268,7 @@ module.exports = async function (input, options = {}) {
                     color: options.embedColor,
                     fields: [],
                     author: { name: usertag, icon_url: avatar },
-                    footer: { text: translations.stopTip }
+                    footer: { text: !input.user ? translations.stopTip : "" }
                 }
                     
                 if (!options.useButtons) updatedAkiEmbed.fields.push({ name: translations.pleaseType, value: `**Y** or **${translations.yes}**\n**N** or **${translations.no}**\n**I** or **IDK**\n**P** or **${translations.probably}**\n**PN** or **${translations.probablyNot}**\n**B** or **${translations.back}**` })


### PR DESCRIPTION
Just made it check whether an interaction had a user property and if so, to leave out the stop tip footer since there is a stop button that they can click. I tested it and it seems to be working fine. 