### PR TITLE
Removed excess regions that were removed from the api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,7 @@ module.exports = async function (input, options) {
         }
 
         //starts the game
-        let gameTypeRegion = options.gameType == "animal" ? "en_animals" : options.gameType == "character" ? "en" : "en_objects";
-        let aki = new Aki({ region: gameTypeRegion, childMode: options.childMode });
+        let aki = new Aki({ region: options.gameType, childMode: options.childMode });
         let akiData = await aki.start();
 
         let notFinished = true;


### PR DESCRIPTION
aki-api no longer uses `en_objects` or `en_animals` etc. They only use `en`, `ar`, `de`, `cn`, etc,

As shown in commit https://github.com/jgoralcz/aki-api/commit/167f05794437951d6e74dfdfab5a3142a3622e56#diff-c67d5ecb0f0d072c796538aa31af225b73f3ce7d1cfd857868df6d4f57b84cb2